### PR TITLE
Merge secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,22 @@ apply-k8s-utils:
 	terraform init; \
 	terraform apply
 
-.PHONY: apply apply-remote-state apply-secrets apply-env apply-k8s-utils
+teardown: teardown-k8s-utils teardown-env teardown-secrets teardown-remote-state
+
+teardown-remote-state: 
+	pushd terraform/bootstrap/remote-state; \
+	terraform destroy;
+
+teardown-secrets: 
+	pushd terraform/bootstrap/secrets; \
+	terraform destroy -auto-approve;
+
+teardown-env: 
+	pushd terraform/environments/$(ENV); \
+	terraform destroy -auto-approve;
+
+teardown-k8s-utils:
+	pushd kubernetes/terraform/environments/$(ENV); \
+	terraform destroy;
+
+.PHONY: apply apply-remote-state apply-secrets apply-env apply-k8s-utils teardown-k8s-utils teardown-env teardown-secrets teardown-remote-state

--- a/terraform/bootstrap/secrets/main.tf
+++ b/terraform/bootstrap/secrets/main.tf
@@ -1,48 +1,26 @@
-provider "aws" {
-  region  = "<% index .Params `region` %>"
-}
+provider "aws" {	
+  region  = "<% index .Params `region` %>"	
+}	
 
-terraform {
-  required_version = ">= 0.12"
-}
+terraform {	
+  required_version = ">= 0.12"	
+}	
 
-# Create the CI User
-resource "aws_iam_user" "ci_user" {
-  name = "ci-user"
-}
+# Create the CI User	
+resource "aws_iam_user" "ci_user" {	
+  name = "${var.project}-ci-user"	
+}	
 
-# Create a keypair to be used by CI systems
-resource "aws_iam_access_key" "ci_user" {
-  user    = aws_iam_user.ci_user.name
-}
+# Create a keypair to be used by CI systems	
+resource "aws_iam_access_key" "ci_user" {	
+  user    = aws_iam_user.ci_user.name	
+}	
 
-# Add the keys to AWS secrets manager
-module "ci_user_keys" {
-  source  = "../../modules/secret"
+# Add the keys to AWS secrets manager	
+module "ci_user_keys" {	
+  source  = "../../modules/secret"	
 
-  name    = "ci-user-aws-keys"
-  type    = "map"
-  values  = map("access_key_id", aws_iam_access_key.ci_user.id, "secret_key", aws_iam_access_key.ci_user.secret)
-}
-
-
- # Create db credentials
- # Unfortunately tf doesn't yet allow you to use for_each with calls to modules
- locals {
-   project = "<% .Name %>"
- }
-
-module "db_password-staging" {
-  source    = "../../modules/secret"
-
-  name      = "${local.project}-staging-rds-master-password"
-  type      = "random"
-}
-
-module "db_password-production" {
-  source        = "../../modules/secret"
-
-  name          = "${local.project}-production-rds-master-password"
-  type          = "random"
-  random_length = 32
-}
+  name_prefix    = "ci-user-aws-keys"	
+  type    = "map"	
+  values  = map("access_key_id", aws_iam_access_key.ci_user.id, "secret_key", aws_iam_access_key.ci_user.secret)	
+}	

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -19,7 +19,7 @@ module "production" {
   region              = "<% index .Params `region` %>"
   allowed_account_ids = ["<% index .Params `accountId` %>"]
   # ECR configuration
-  ecr_repositories = ["production"]
+  ecr_repositories = ["<% .Name %>-production"]
 
   # EKS configuration
   eks_cluster_version      = "1.15"

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -19,7 +19,7 @@ module "staging" {
   region              = "<% index .Params `region` %>"
   allowed_account_ids = ["<% index .Params `accountId` %>"]
   # ECR configuration
-  ecr_repositories = [ "gql-server" ]
+  ecr_repositories = [ "<% .Name %>-staging" ]
 
   # EKS configuration
   eks_cluster_version      = "1.15"

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -71,7 +71,7 @@ module "rds" {
 
   # DB parameter and option group
   family = "postgres11"
-  major_engine_version = "11.5"
+  major_engine_version = "11"
 
   final_snapshot_identifier = "final-snapshot"
   deletion_protection = true

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -28,9 +28,16 @@ module "rds_security_group" {
 data "aws_caller_identity" "current" {
 }
 
-# This is created by bootstrap/secrets
+# creating RDS password in secret-manager
+module "db_password" {
+  source    = "../secret"
+  name_prefix      = "${var.project}-${var.environment}-rds-master-password"
+  type      = "random"
+}
+
+# RDS does not support secret-manager, have to provide the actual string
 data "aws_secretsmanager_secret_version" "rds_master_secret" {
-  secret_id = "${var.project}-${var.environment}-rds-master-password"
+  secret_id = module.db_password.secret_name
 }
 
 module "rds" {

--- a/terraform/modules/environment/main.tf
+++ b/terraform/modules/environment/main.tf
@@ -51,7 +51,7 @@ module "eks" {
 }
 
 data "aws_iam_user" "ci_user" {
-  user_name = "ci-user" # Should have been created in the bootstrap process
+  user_name = "${var.project}-ci-user"  # Should have been created in the bootstrap process
 }
 
 module "wildcard_domain" {
@@ -97,5 +97,5 @@ module "ecr" {
 
   environment       = var.environment
   ecr_repositories  = var.ecr_repositories
-  ecr_principals    = [data.aws_iam_user.ci_user.arn]
+  ecr_principals    = [aws_iam_user.ci_user.arn]
 }

--- a/terraform/modules/secret/main.tf
+++ b/terraform/modules/secret/main.tf
@@ -1,6 +1,6 @@
 # Add the keys to AWS secrets manager
 resource "aws_secretsmanager_secret" "secret" {
-  name = var.name
+  name_prefix = var.name_prefix
 }
 
 resource "aws_secretsmanager_secret_version" "string_secret" {

--- a/terraform/modules/secret/variables.tf
+++ b/terraform/modules/secret/variables.tf
@@ -1,5 +1,6 @@
-variable "name" {
-  description = "The name of the secret in Secrets Manager"
+variable "name_prefix" {
+  default = "secret-key"
+  description = "The name prefix of the secret in Secrets Manager"
 }
 
 variable type {


### PR DESCRIPTION
secret names are unique and long-lived(soft delete) and
names are not reusable, so for development/shared env purposes it
will be nicer to have secrets use a name_prefix to avoid name conflicts

Note: originally secret was put in a separate TF state so the secrets
can be referenced by name only, but RDS does not support secret-manager
