### PR TITLE
fix: missing module output file

### DIFF
--- a/kubernetes/terraform/modules/kubernetes/kubernetes_dashboard.tf
+++ b/kubernetes/terraform/modules/kubernetes/kubernetes_dashboard.tf
@@ -3,6 +3,7 @@ resource "kubernetes_service_account" "kubernetes_dashboard_user" {
     name      = "dashboard-user"
     namespace = "kubernetes-dashboard"
   }
+  depends_on = [kubernetes_namespace.kubernetes_dashboard]
 }
 
 resource "kubernetes_cluster_role_binding" "kubernetes_dashboard_user" {
@@ -33,6 +34,7 @@ resource "kubernetes_service_account" "kubernetes_dashboard" {
     namespace = "kubernetes-dashboard"
     labels    = { k8s-app = "kubernetes-dashboard" }
   }
+  depends_on = [kubernetes_namespace.kubernetes_dashboard]
 }
 
 resource "kubernetes_service" "kubernetes_dashboard" {

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -30,9 +30,10 @@ data "aws_caller_identity" "current" {
 
 # creating RDS password in secret-manager
 module "db_password" {
-  source    = "../secret"
-  name_prefix      = "${var.project}-${var.environment}-rds-master-password"
-  type      = "random"
+  source      = "../secret"
+  type        = "random"
+  ## note: secret name_prefix has a limitation of 32 characters 
+  name_prefix = "${var.project}-${var.environment}-rds"
 }
 
 # RDS does not support secret-manager, have to provide the actual string

--- a/terraform/modules/secret/output.tf
+++ b/terraform/modules/secret/output.tf
@@ -1,0 +1,3 @@
+output "secret_name" { 
+  value = aws_secretsmanager_secret.secret.name
+}


### PR DESCRIPTION
- Karim and Sophie both ran into issue where during service_account creation it complained `namespace not found` 

- reducing length of name_prefix for secret due to character limitation 

- missed a file 😞 , my git workflow uses `git add -u` so i missed a file while commiting to #14, basically a only works on my local scenario 