### PR TITLE
K8s utils qol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,12 @@ apply-env:
 	terraform init; \
 	terraform apply
 
-apply-k8s-utils:
+apply-k8s-utils: update-k8s-conf
 	pushd kubernetes/terraform/environments/$(ENV); \
 	terraform init; \
 	terraform apply
+
+update-k8s-conf: eks --region <% index .Params `region` %> update-kubeconfig --name <% .Name %>-$(ENV)-<% index .Params `region` %>
 
 teardown: teardown-k8s-utils teardown-env teardown-secrets teardown-remote-state
 

--- a/kubernetes/terraform/modules/kubernetes/kubernetes_dashboard.tf
+++ b/kubernetes/terraform/modules/kubernetes/kubernetes_dashboard.tf
@@ -233,6 +233,7 @@ resource "kubernetes_deployment" "kubernetes_dashboard" {
     }
     revision_history_limit = 10
   }
+  depends_on = [kubernetes_role_binding.kubernetes_dashboard]
 }
 
 resource "kubernetes_service" "dashboard_metrics_scraper" {

--- a/terraform/modules/database/main.tf
+++ b/terraform/modules/database/main.tf
@@ -36,9 +36,16 @@ module "db_password" {
   name_prefix = "${var.project}-${var.environment}-rds"
 }
 
+# secret declared so secret version waits for rds-secret to be ready
+# or else we often see a AWSDEFAULT VERSION secret not found error
+data "aws_secretsmanager_secret" "rds_master_secret" {
+  name = module.db_password.secret_name
+}
+
 # RDS does not support secret-manager, have to provide the actual string
 data "aws_secretsmanager_secret_version" "rds_master_secret" {
-  secret_id = module.db_password.secret_name
+  secret_id = data.aws_secretsmanager_secret.rds_master_secret.name
+  depends_on = [data.aws_secretsmanager_secret.rds_master_secret]
 }
 
 module "rds" {


### PR DESCRIPTION
1. the jetstack cert-manager out of the box only supports cert-manager being on [cert-manager namespace][1]

2. executing the local files requires the kubeconfig to be updated beforehand

3. kube dashbaord sometimes spins up before the rolebinding 😢 


[1]: https://github.com/commitdev/commit0-aws-eks-stack/blob/a054f7b8d6e0da01494256618e65161f185faaab/kubernetes/terraform/modules/kubernetes/files/cert-manager.crds.yaml#L46